### PR TITLE
new_lint non_reentrant_functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4782,6 +4782,7 @@ Released 2018-09-13
 [`no_mangle_with_rust_abi`]: https://rust-lang.github.io/rust-clippy/master/index.html#no_mangle_with_rust_abi
 [`non_ascii_literal`]: https://rust-lang.github.io/rust-clippy/master/index.html#non_ascii_literal
 [`non_octal_unix_permissions`]: https://rust-lang.github.io/rust-clippy/master/index.html#non_octal_unix_permissions
+[`non_reentrant_functions`]: https://rust-lang.github.io/rust-clippy/master/index.html#non_reentrant_functions
 [`non_send_fields_in_send_ty`]: https://rust-lang.github.io/rust-clippy/master/index.html#non_send_fields_in_send_ty
 [`nonminimal_bool`]: https://rust-lang.github.io/rust-clippy/master/index.html#nonminimal_bool
 [`nonsensical_open_options`]: https://rust-lang.github.io/rust-clippy/master/index.html#nonsensical_open_options

--- a/clippy_lints/src/declared_lints.rs
+++ b/clippy_lints/src/declared_lints.rs
@@ -471,6 +471,7 @@ pub(crate) static LINTS: &[&crate::LintInfo] = &[
     crate::non_expressive_names::MANY_SINGLE_CHAR_NAMES_INFO,
     crate::non_expressive_names::SIMILAR_NAMES_INFO,
     crate::non_octal_unix_permissions::NON_OCTAL_UNIX_PERMISSIONS_INFO,
+    crate::non_reentrant_functions::NON_REENTRANT_FUNCTIONS_INFO,
     crate::non_send_fields_in_send_ty::NON_SEND_FIELDS_IN_SEND_TY_INFO,
     crate::nonstandard_macro_braces::NONSTANDARD_MACRO_BRACES_INFO,
     crate::octal_escapes::OCTAL_ESCAPES_INFO,

--- a/clippy_lints/src/lib.rs
+++ b/clippy_lints/src/lib.rs
@@ -232,6 +232,7 @@ mod no_mangle_with_rust_abi;
 mod non_copy_const;
 mod non_expressive_names;
 mod non_octal_unix_permissions;
+mod non_reentrant_functions;
 mod non_send_fields_in_send_ty;
 mod nonstandard_macro_braces;
 mod octal_escapes;
@@ -966,6 +967,7 @@ pub fn register_plugins(store: &mut rustc_lint::LintStore, sess: &Session, conf:
     store.register_late_pass(move |_| Box::new(guidelines::GuidelineLints::new(mem_unsafe_functions.clone())));
     store.register_late_pass(|_| Box::new(unsafe_block_in_proc_macro::UnsafeBlockInProcMacro::new()));
     store.register_early_pass(|| Box::new(implicit_abi::ImplicitAbi));
+    store.register_early_pass(|| Box::new(non_reentrant_functions::NonReentrantFunctions));
     // add lints here, do not remove this comment, it's used in `new_lint`
 }
 

--- a/clippy_lints/src/non_reentrant_functions.rs
+++ b/clippy_lints/src/non_reentrant_functions.rs
@@ -46,8 +46,10 @@ impl EarlyLintPass for NonReentrantFunctions {
 fn is_reentrant_fn(func: &Expr) -> bool {
     match &func.kind {
         ExprKind::Path(_, Path { segments, .. }) => {
-            let seg = segments.iter().last().unwrap();
-            let ident = format!("{:?}", seg.ident);
+            if segments.len() != 2 || !format!("{:?}", segments[0].ident).starts_with("libc#") {
+                return false;
+            }
+            let ident = format!("{:?}", segments[1].ident);
             check_reentrant_by_fn_name(&ident)
         },
         _ => false,

--- a/clippy_lints/src/non_reentrant_functions.rs
+++ b/clippy_lints/src/non_reentrant_functions.rs
@@ -35,13 +35,10 @@ impl EarlyLintPass for NonReentrantFunctions {
 
         let msg: &str = "consider using the reentrant version of the function";
 
-        match expr.kind {
-            ExprKind::Call(ref func, _) => {
-                if is_reentrant_fn(func) {
-                    span_lint(cx, NON_REENTRANT_FUNCTIONS, expr.span, msg);
-                }
-            },
-            _ => {},
+        if let ExprKind::Call(func, _) = &expr.kind {
+            if is_reentrant_fn(func) {
+                span_lint(cx, NON_REENTRANT_FUNCTIONS, expr.span, msg);
+            }
         }
     }
 }
@@ -58,6 +55,6 @@ fn is_reentrant_fn(func: &Expr) -> bool {
 }
 
 fn check_reentrant_by_fn_name(func: &str) -> bool {
-    let name = func.split("#").next().unwrap();
+    let name = func.split('#').next().unwrap();
     name == "strtok" || name == "localtime"
 }

--- a/clippy_lints/src/non_reentrant_functions.rs
+++ b/clippy_lints/src/non_reentrant_functions.rs
@@ -46,17 +46,11 @@ impl EarlyLintPass for NonReentrantFunctions {
 fn is_reentrant_fn(func: &Expr) -> bool {
     match &func.kind {
         ExprKind::Path(_, Path { segments, .. }) => {
-            if segments.len() != 2 || !format!("{:?}", segments[0].ident).starts_with("libc#") {
+            if segments.len() != 2 || segments[0].ident.name != rustc_span::sym::libc {
                 return false;
             }
-            let ident = format!("{:?}", segments[1].ident);
-            check_reentrant_by_fn_name(&ident)
+            matches!(segments[1].ident.as_str(), "strtok" | "localtime")
         },
         _ => false,
     }
-}
-
-fn check_reentrant_by_fn_name(func: &str) -> bool {
-    let name = func.split('#').next().unwrap();
-    name == "strtok" || name == "localtime"
 }

--- a/clippy_lints/src/non_reentrant_functions.rs
+++ b/clippy_lints/src/non_reentrant_functions.rs
@@ -1,0 +1,59 @@
+use clippy_utils::diagnostics::span_lint;
+use rustc_ast::ast::{Expr, ExprKind, Path};
+use rustc_lint::{EarlyContext, EarlyLintPass};
+use rustc_session::{declare_lint_pass, declare_tool_lint};
+
+declare_clippy_lint! {
+    /// ### What it does
+    ///
+    /// ### Why is this bad?
+    ///
+    /// ### Example
+    /// ```rust
+    /// // example code where clippy issues a warning
+    /// ```
+    /// Use instead:
+    /// ```rust
+    /// // example code which does not raise clippy warning
+    /// ```
+    #[clippy::version = "1.70.0"]
+    pub NON_REENTRANT_FUNCTIONS,
+    nursery,
+    "this function is a non-reentrant-function"
+}
+declare_lint_pass!(NonReentrantFunctions => [NON_REENTRANT_FUNCTIONS]);
+
+impl EarlyLintPass for NonReentrantFunctions {
+    fn check_expr(&mut self, cx: &EarlyContext<'_>, expr: &Expr) {
+        if expr.span.from_expansion() {
+            return;
+        }
+
+        let msg: &str = "consider using the reentrant version of the function";
+
+        match expr.kind {
+            ExprKind::Call(ref func, _) => {
+                if is_reentrant_fn(func) {
+                    span_lint(cx, NON_REENTRANT_FUNCTIONS, expr.span, msg);
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+fn is_reentrant_fn(func: &Expr) -> bool {
+    match &func.kind {
+        ExprKind::Path(_, Path { segments, .. }) => {
+            let seg = segments.iter().last().unwrap();
+            let ident = format!("{:?}", seg.ident);
+            check_reentrant_by_fn_name(&ident)
+        },
+        _ => false,
+    }
+}
+
+fn check_reentrant_by_fn_name(func: &str) -> bool {
+    let name = func.split("#").next().unwrap();
+    name == "strtok" || name == "localtime"
+}

--- a/clippy_lints/src/non_reentrant_functions.rs
+++ b/clippy_lints/src/non_reentrant_functions.rs
@@ -5,16 +5,20 @@ use rustc_session::{declare_lint_pass, declare_tool_lint};
 
 declare_clippy_lint! {
     /// ### What it does
+    /// Checks for non-reentrant functions.
     ///
     /// ### Why is this bad?
+    /// This makes code safer, especially in the context of concurrency.
     ///
     /// ### Example
     /// ```rust
-    /// // example code where clippy issues a warning
+    /// let _tm = libc::localtime(&0i64 as *const libc::time_t);
     /// ```
     /// Use instead:
     /// ```rust
-    /// // example code which does not raise clippy warning
+    /// let res = libc::malloc(std::mem::size_of::<libc::tm>());
+    ///
+    /// libc::locatime_r(&0i64 as *const libc::time_t, res);
     /// ```
     #[clippy::version = "1.70.0"]
     pub NON_REENTRANT_FUNCTIONS,

--- a/tests/ui/non_reentrant_functions.rs
+++ b/tests/ui/non_reentrant_functions.rs
@@ -1,25 +1,38 @@
 #![warn(clippy::non_reentrant_functions)]
+#![allow(unused)]
 #![feature(rustc_private)]
 extern crate libc;
 
-#[allow(unused)]
-use libc::{c_char, localtime, strtok, time_t};
 use std::ffi::{CStr, CString};
 
-fn main() {
+fn test_libc_localtime() {
     // test code goes here
     unsafe {
-        let _tm = localtime(&0i64 as *const time_t);
+        let _tm = libc::localtime(&0i64 as *const libc::time_t);
     }
+}
 
+fn test_libc_strtok() {
     let string = CString::new("welcome-to-rust").unwrap();
-    let string = string.as_ptr() as *mut c_char;
+    let string = string.as_ptr() as *mut libc::c_char;
     let delim = CString::new(" - ").unwrap();
     let delim = delim.as_ptr();
 
-    let mut token = unsafe { strtok(string, delim) };
+    let mut token = unsafe { libc::strtok(string, delim) };
     while !token.is_null() {
         println!("{:?}", unsafe { CStr::from_ptr(token) });
-        token = unsafe { strtok(std::ptr::null_mut(), delim) };
+        token = unsafe { libc::strtok(std::ptr::null_mut(), delim) };
     }
 }
+
+fn test_locatime() {
+    fn localtime() {}
+    localtime();
+}
+
+fn test_strtok() {
+    fn strtok() {}
+    strtok();
+}
+
+fn main() {}

--- a/tests/ui/non_reentrant_functions.rs
+++ b/tests/ui/non_reentrant_functions.rs
@@ -1,0 +1,25 @@
+#![warn(clippy::non_reentrant_functions)]
+#![feature(rustc_private)]
+extern crate libc;
+
+#[allow(unused)]
+use libc::{c_char, localtime, strtok, time_t};
+use std::ffi::{CStr, CString};
+
+fn main() {
+    // test code goes here
+    unsafe {
+        let _tm = localtime(&0i64 as *const time_t);
+    }
+
+    let string = CString::new("welcome-to-rust").unwrap();
+    let string = string.as_ptr() as *mut c_char;
+    let delim = CString::new(" - ").unwrap();
+    let delim = delim.as_ptr();
+
+    let mut token = unsafe { strtok(string, delim) };
+    while !token.is_null() {
+        println!("{:?}", unsafe { CStr::from_ptr(token) });
+        token = unsafe { strtok(std::ptr::null_mut(), delim) };
+    }
+}

--- a/tests/ui/non_reentrant_functions.stderr
+++ b/tests/ui/non_reentrant_functions.stderr
@@ -1,22 +1,22 @@
 error: consider using the reentrant version of the function
-  --> $DIR/non_reentrant_functions.rs:12:19
+  --> $DIR/non_reentrant_functions.rs:11:19
    |
-LL |         let _tm = localtime(&0i64 as *const time_t);
-   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         let _tm = libc::localtime(&0i64 as *const libc::time_t);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: `-D clippy::non-reentrant-functions` implied by `-D warnings`
 
 error: consider using the reentrant version of the function
-  --> $DIR/non_reentrant_functions.rs:20:30
+  --> $DIR/non_reentrant_functions.rs:21:30
    |
-LL |     let mut token = unsafe { strtok(string, delim) };
-   |                              ^^^^^^^^^^^^^^^^^^^^^
+LL |     let mut token = unsafe { libc::strtok(string, delim) };
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: consider using the reentrant version of the function
-  --> $DIR/non_reentrant_functions.rs:23:26
+  --> $DIR/non_reentrant_functions.rs:24:26
    |
-LL |         token = unsafe { strtok(std::ptr::null_mut(), delim) };
-   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+LL |         token = unsafe { libc::strtok(std::ptr::null_mut(), delim) };
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: aborting due to 3 previous errors
 

--- a/tests/ui/non_reentrant_functions.stderr
+++ b/tests/ui/non_reentrant_functions.stderr
@@ -1,0 +1,22 @@
+error: consider using the reentrant version of the function
+  --> $DIR/non_reentrant_functions.rs:12:19
+   |
+LL |         let _tm = localtime(&0i64 as *const time_t);
+   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `-D clippy::non-reentrant-functions` implied by `-D warnings`
+
+error: consider using the reentrant version of the function
+  --> $DIR/non_reentrant_functions.rs:20:30
+   |
+LL |     let mut token = unsafe { strtok(string, delim) };
+   |                              ^^^^^^^^^^^^^^^^^^^^^
+
+error: consider using the reentrant version of the function
+  --> $DIR/non_reentrant_functions.rs:23:26
+   |
+LL |         token = unsafe { strtok(std::ptr::null_mut(), delim) };
+   |                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
Thank you for making Clippy better!

We're collecting our changelog from pull request descriptions.
If your PR only includes internal changes, you can just write
`changelog: none`. Otherwise, please write a short comment
explaining your change.

It's also helpful for us that the lint name is put within backticks (`` ` ` ``),
and then encapsulated by square brackets (`[]`), for example:
```
changelog: [`lint_name`]: your change
```

If your PR fixes an issue, you can add `fixes #issue_number` into this
PR description. This way the issue will be automatically closed when
your PR is merged.

If you added a new lint, here's a checklist for things that will be
checked during review or continuous integration.

- \[ ] Followed [lint naming conventions][lint_naming]
- \[ ] Added passing UI tests (including committed `.stderr` file)
- \[ ] `cargo test` passes locally
- \[ ] Executed `cargo dev update_lints`
- \[ ] Added lint documentation
- \[ ] Run `cargo dev fmt`

[lint_naming]: https://rust-lang.github.io/rfcs/0344-conventions-galore.html#lints

Note that you can skip the above if you are just opening a WIP PR in
order to get feedback.

Delete this line and everything above before opening your PR.

---

*Please write a short comment explaining your change (or "none" for internal only changes)*

changelog:
