### PR TITLE
fix test fail after dev fmt of [`implicit_abi`]

### DIFF
--- a/tests/ui/implicit_abi.fixed
+++ b/tests/ui/implicit_abi.fixed
@@ -7,6 +7,7 @@ use std::ffi::{c_char, c_void};
 #[repr(C)]
 pub struct External(i8);
 
+#[rustfmt::skip]
 extern "C" {
     fn foo();
     fn bar(a: u8, b: i32) -> u64;

--- a/tests/ui/implicit_abi.rs
+++ b/tests/ui/implicit_abi.rs
@@ -7,6 +7,7 @@ use std::ffi::{c_char, c_void};
 #[repr(C)]
 pub struct External(i8);
 
+#[rustfmt::skip]
 extern {
     fn foo();
     fn bar(a: u8, b: i32) -> u64;

--- a/tests/ui/implicit_abi.stderr
+++ b/tests/ui/implicit_abi.stderr
@@ -1,5 +1,5 @@
 error: missing ABI label on extern block
-  --> $DIR/implicit_abi.rs:10:1
+  --> $DIR/implicit_abi.rs:11:1
    |
 LL | extern {
    | ^^^^^^ help: explicitly states ABI instead: `extern "C"`
@@ -7,13 +7,13 @@ LL | extern {
    = note: `-D clippy::implicit-abi` implied by `-D warnings`
 
 error: missing ABI label on extern block
-  --> $DIR/implicit_abi.rs:22:1
+  --> $DIR/implicit_abi.rs:23:1
    |
 LL | extern
    | ^^^^^^ help: explicitly states ABI instead: `extern "C"`
 
 error: missing ABI label on extern block
-  --> $DIR/implicit_abi.rs:28:1
+  --> $DIR/implicit_abi.rs:29:1
    |
 LL | extern { fn my_c_fn(a: i8) -> c_void; }
    | ^^^^^^ help: explicitly states ABI instead: `extern "C"`


### PR DESCRIPTION

changelog: skip rustfmt in uitest for [`implicit_abi`]
