### PR TITLE
improve lint [`extern_without_repr`]

### DIFF
--- a/tests/ui/guidelines/extern_without_repr.rs
+++ b/tests/ui/guidelines/extern_without_repr.rs
@@ -1,44 +1,70 @@
 #![allow(unused)]
-#![allow(improper_ctypes_definitions)]
-#![allow(improper_ctypes)]
+#![allow(improper_ctypes, improper_ctypes_definitions)]
 #![warn(clippy::extern_without_repr)]
 #![feature(rustc_private)]
-#![feature(core_intrinsics)]
+#![feature(repr_simd, simd_ffi)]
 extern crate libc;
 
+use std::ffi::c_int;
+
 #[repr(C)]
-struct Foo1 {
+struct ReprC {
     a: i32,
     b: i64,
-    c: u128,
 }
 
 #[repr(packed)]
 #[derive(Debug, Clone, Copy)]
-struct Foo2 {
+struct Packed {
     a: libc::c_char,
     b: libc::c_int,
     c: libc::c_longlong,
 }
 
-struct Foo3 {
-    a: libc::c_char,
-    b: libc::c_int,
-    c: libc::c_longlong,
+#[repr(align(2))]
+struct Aligned {
+    inner: c_int,
 }
 
-extern "C" fn c_abi_fn1(arg_one: u32, arg_two: usize) {}
-extern "C" fn c_abi_fn2(arg_one: u32, arg_two: Foo1) {}
-extern "C" fn c_abi_fn3(arg_one: u32, arg_two: *const Foo2) {}
-extern "C" fn c_abi_fn4(arg_one: u32, arg_two: *const Foo3) {}
+#[repr(simd)]
+struct ReprSimd {
+    inner: c_int,
+}
+
+#[repr(transparent)]
+struct Transparent {
+    inner: c_int,
+}
+
+struct NakedStruct {
+    a: libc::c_char,
+}
+
+pub enum NakedEnum {
+    A,
+    B,
+}
+
+extern "C" fn c_abi_fn1(arg: c_int) {}
+extern "C" fn c_abi_fn2(arg_one: c_int, arg_two: ReprC) {}
+extern "C" fn c_abi_fn3(arg_one: c_int, arg_two: *const Packed) {}
+extern "C" fn c_abi_fn4(arg: Aligned) {}
+extern "C" fn c_abi_fn5(arg: ReprSimd) {}
+extern "C" fn c_abi_fn6(arg: Transparent) {}
+extern "C" fn bad1(arg_one: c_int, arg_two: *const NakedStruct) {}
+extern "C" fn bad2(arg: NakedStruct) {}
+extern "C" fn bad3(arg: NakedEnum) {}
+extern "C" fn bad4(arg: NakedEnum, arg2: NakedStruct) {}
 
 extern "C" {
-    fn c_abi_in_block1(arg_one: u32, arg_two: usize);
-    fn c_abi_in_block2(arg_one: u32, arg_two: Foo1);
-    fn c_abi_in_block3(arg_one: u32, arg_two: Foo2);
-    fn c_abi_in_block4(arg_one: u32, arg_two: Foo3);
+    fn c_abi_in_block1(arg_one: c_int);
+    fn c_abi_in_block2(arg_one: c_int, arg_two: ReprC);
+    fn c_abi_in_block3(arg_one: c_int, arg_two: Packed);
+    fn c_abi_in_block4(arg: Aligned);
+    fn c_abi_in_block5(arg: ReprSimd);
+    fn bad_in_block1(arg_one: c_int, arg_two: NakedStruct);
+    fn bad_in_block2(arg: *mut NakedEnum);
+    fn bad_in_block3(arg: *mut NakedEnum, arg2: NakedStruct, arg3: *const ReprSimd);
 }
 
-fn main() {
-    // test code goes here
-}
+fn main() {}

--- a/tests/ui/guidelines/extern_without_repr.stderr
+++ b/tests/ui/guidelines/extern_without_repr.stderr
@@ -1,10 +1,147 @@
-error: Should use repr to specifing data layout when struct is used in FFI
-  --> $DIR/extern_without_repr.rs:24:1
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:52:30
    |
-LL | struct Foo3 {
-   | ^^^^^^^^^^^
+LL | extern "C" fn c_abi_fn5(arg: ReprSimd) {}
+   |                              ^^^^^^^^
    |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:30:1
+   |
+LL | struct ReprSimd {
+   | ^^^^^^^^^^^^^^^
    = note: `-D clippy::extern-without-repr` implied by `-D warnings`
 
-error: aborting due to previous error
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:54:45
+   |
+LL | extern "C" fn bad1(arg_one: c_int, arg_two: *const NakedStruct) {}
+   |                                             ^^^^^^^^^^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:39:1
+   |
+LL | struct NakedStruct {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:55:25
+   |
+LL | extern "C" fn bad2(arg: NakedStruct) {}
+   |                         ^^^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:39:1
+   |
+LL | struct NakedStruct {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:56:25
+   |
+LL | extern "C" fn bad3(arg: NakedEnum) {}
+   |                         ^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:43:1
+   |
+LL | pub enum NakedEnum {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:57:25
+   |
+LL | extern "C" fn bad4(arg: NakedEnum, arg2: NakedStruct) {}
+   |                         ^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:43:1
+   |
+LL | pub enum NakedEnum {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:57:42
+   |
+LL | extern "C" fn bad4(arg: NakedEnum, arg2: NakedStruct) {}
+   |                                          ^^^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:39:1
+   |
+LL | struct NakedStruct {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:64:29
+   |
+LL |     fn c_abi_in_block5(arg: ReprSimd);
+   |                             ^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:30:1
+   |
+LL | struct ReprSimd {
+   | ^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:65:47
+   |
+LL |     fn bad_in_block1(arg_one: c_int, arg_two: NakedStruct);
+   |                                               ^^^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:39:1
+   |
+LL | struct NakedStruct {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:66:27
+   |
+LL |     fn bad_in_block2(arg: *mut NakedEnum);
+   |                           ^^^^^^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:43:1
+   |
+LL | pub enum NakedEnum {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:67:27
+   |
+LL |     fn bad_in_block3(arg: *mut NakedEnum, arg2: NakedStruct, arg3: *const ReprSimd);
+   |                           ^^^^^^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:43:1
+   |
+LL | pub enum NakedEnum {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:67:49
+   |
+LL |     fn bad_in_block3(arg: *mut NakedEnum, arg2: NakedStruct, arg3: *const ReprSimd);
+   |                                                 ^^^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:39:1
+   |
+LL | struct NakedStruct {
+   | ^^^^^^^^^^^^^^^^^^
+
+error: should use `#[repr(..)]` to specifing data layout when type is used in FFI
+  --> $DIR/extern_without_repr.rs:67:68
+   |
+LL |     fn bad_in_block3(arg: *mut NakedEnum, arg2: NakedStruct, arg3: *const ReprSimd);
+   |                                                                    ^^^^^^^^^^^^^^^
+   |
+note: type declared here
+  --> $DIR/extern_without_repr.rs:30:1
+   |
+LL | struct ReprSimd {
+   | ^^^^^^^^^^^^^^^
+
+error: aborting due to 12 previous errors
 


### PR DESCRIPTION
changelog:
- add more test cases for [`extern_without_repr`]
- disallow `repr(simd)` for extern mod funtion items
- improve error messages and include type usage span
- code refractoring
