### PR TITLE
support adding `..` to extend `guidelines` related configurations

### DIFF
--- a/clippy_lints/src/utils/conf.rs
+++ b/clippy_lints/src/utils/conf.rs
@@ -780,6 +780,16 @@ pub fn read(sess: &Session, path: &Path) -> TryConf {
         Ok(mut conf) => {
             extend_vec_if_indicator_present(&mut conf.conf.doc_valid_idents, DEFAULT_DOC_VALID_IDENTS);
             extend_vec_if_indicator_present(&mut conf.conf.disallowed_names, DEFAULT_DISALLOWED_NAMES);
+            extend_vec_if_indicator_present(&mut conf.conf.mem_unsafe_functions, DEFAULT_MEM_UNSAFE_FUNCTIONS);
+            extend_vec_if_indicator_present(&mut conf.conf.non_reentrant_functions, DEFAULT_NON_REENTRANT_FNS);
+            extend_vec_if_indicator_present(
+                &mut conf.conf.size_checking_function_keywords,
+                DEFAULT_SIZE_CHECK_FN_KEYWORDS,
+            );
+            extend_vec_if_indicator_present(&mut conf.conf.mem_alloc_functions, DEFAULT_MEM_ALLOC_FNS);
+            extend_vec_if_indicator_present(&mut conf.conf.mem_free_functions, DEFAULT_MEM_FREE_FNS);
+            extend_vec_if_indicator_present(&mut conf.conf.input_functions, DEFAULT_INPUT_FUNCTIONS);
+            extend_vec_if_indicator_present(&mut conf.conf.lib_loading_functions, DEFAULT_LIB_LOADING_FNS);
             // TODO: THIS SHOULD BE TESTED, this comment will be gone soon
             if conf.conf.allowed_idents_below_min_chars.contains(&"..".to_owned()) {
                 conf.conf

--- a/tests/ui-toml/guidelines/clippy.toml
+++ b/tests/ui-toml/guidelines/clippy.toml
@@ -28,6 +28,7 @@ input-functions = [
 
 # fallible_memory_allocation
 mem-alloc-functions = [
+    "..",
     "std::collections::HashSet::with_capacity",
     "alloc_mem",
     "my_malloc",

--- a/tests/ui-toml/guidelines/fallible_memory_allocation.rs
+++ b/tests/ui-toml/guidelines/fallible_memory_allocation.rs
@@ -34,7 +34,7 @@ fn exit_on_bad_size(s: usize) {
 
 unsafe fn foo1() {
     let size = get_untrusted_size();
-    let p = malloc(size); // don't lint, not configured
+    let p = malloc(size); // lint
     let p = my_malloc(size); // lint
 }
 
@@ -74,7 +74,7 @@ unsafe fn null_ptr_checker() {
 
 fn safe() {
     let size = get_untrusted_size();
-    let arr: Vec<u8> = Vec::with_capacity(size); // don't lint, not configured
+    let arr: Vec<u8> = Vec::with_capacity(size); // lint
 
     let size = get_untrusted_size();
     let arr: HashSet<u8> = HashSet::with_capacity(size); // lint

--- a/tests/ui-toml/guidelines/fallible_memory_allocation.stderr
+++ b/tests/ui-toml/guidelines/fallible_memory_allocation.stderr
@@ -1,4 +1,24 @@
 error: allocating memory without verifying the size
+  --> $DIR/fallible_memory_allocation.rs:37:13
+   |
+LL |     let p = malloc(size); // lint
+   |             ^^^^^^^^^^^^
+   |
+note: unverified size used here
+  --> $DIR/fallible_memory_allocation.rs:37:20
+   |
+LL |     let p = malloc(size); // lint
+   |                    ^^^^
+   = note: `-D clippy::fallible-memory-allocation` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::fallible_memory_allocation)]`
+
+error: allocating memory without checking if the result pointer is null
+  --> $DIR/fallible_memory_allocation.rs:37:13
+   |
+LL |     let p = malloc(size); // lint
+   |             ^^^^^^^^^^^^
+
+error: allocating memory without verifying the size
   --> $DIR/fallible_memory_allocation.rs:38:13
    |
 LL |     let p = my_malloc(size); // lint
@@ -9,8 +29,6 @@ note: unverified size used here
    |
 LL |     let p = my_malloc(size); // lint
    |                       ^^^^
-   = note: `-D clippy::fallible-memory-allocation` implied by `-D warnings`
-   = help: to override `-D warnings` add `#[allow(clippy::fallible_memory_allocation)]`
 
 error: allocating memory without checking if the result pointer is null
   --> $DIR/fallible_memory_allocation.rs:38:13
@@ -25,6 +43,18 @@ LL |     let p = alloc_mem(size); // lint
    |             ^^^^^^^^^^^^^^^
 
 error: allocating memory without verifying the size
+  --> $DIR/fallible_memory_allocation.rs:77:24
+   |
+LL |     let arr: Vec<u8> = Vec::with_capacity(size); // lint
+   |                        ^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+note: unverified size used here
+  --> $DIR/fallible_memory_allocation.rs:77:43
+   |
+LL |     let arr: Vec<u8> = Vec::with_capacity(size); // lint
+   |                                           ^^^^
+
+error: allocating memory without verifying the size
   --> $DIR/fallible_memory_allocation.rs:80:28
    |
 LL |     let arr: HashSet<u8> = HashSet::with_capacity(size); // lint
@@ -36,5 +66,5 @@ note: unverified size used here
 LL |     let arr: HashSet<u8> = HashSet::with_capacity(size); // lint
    |                                                   ^^^^
 
-error: aborting due to 4 previous errors
+error: aborting due to 7 previous errors
 


### PR DESCRIPTION

changelog: support adding `..` to extend `guidelines` related configurations
